### PR TITLE
Create default  /etc/default/kubelet before modify it

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,7 @@ EOF
     # ip of this box
     IP_ADDR=`ifconfig enp0s8 | grep Mask | awk '{print $2}'| cut -f2 -d:`
     # set node-ip
+    sudo sh -c 'echo KUBELET_EXTRA_ARGS= >> /etc/default/kubelet'
     sudo sed -i "/^[^#]*KUBELET_EXTRA_ARGS=/c\KUBELET_EXTRA_ARGS=--node-ip=$IP_ADDR" /etc/default/kubelet
     sudo systemctl restart kubelet
 SCRIPT


### PR DESCRIPTION
/etc/default/kubelet is no longer there. 
After read kubernetes's "Do not write the /etc/default/kubelet file when installing kubelet/kubeadm packages #654", I believe they no longer create it by default.